### PR TITLE
Cleanup using transformers

### DIFF
--- a/intercom-haskell.cabal
+++ b/intercom-haskell.cabal
@@ -27,6 +27,8 @@ library
                        , aeson
                        , containers
                        , unordered-containers
+                       , transformers
+                       , mtl
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,14 @@
 > let client = defaultClient & appId .~ "foo" & apiKey .~ "bar"
 
 -- Test your connection
-> ping client
+> withIntercom client ping
 Status {statusCode = 200, statusMessage = "OK"}
 ```
 
 ### Users
 
 ```haskell
-> userList client
+> withIntercom client userList
 Just (UserList {_users = [User {_name = "bob" ...
 ```
 
@@ -23,7 +23,7 @@ Pagination:
 
 ```haskell
 -- Grabs the next page of users from your user list (cycles around at the end)
-> nextPage userList client
+> withIntercom client $ nextPage userList
 Just (UserList {_users = [User {_name = "jim" ...
 ```
 
@@ -31,6 +31,6 @@ Creating/updating:
 
 ```haskell
 > let myUser = blankUser & email .~ (Just "bob@foo.com")
-> createOrUpdateUser myUser client
+> withIntercom client $ createOrUpdateUser myUser
 Just (User {_name = Nothing, _email = Just "bob@foo.com", _userId = Nothing, _customAttributes = fromList []})
 ```

--- a/shell.nix
+++ b/shell.nix
@@ -5,15 +5,15 @@ let
   inherit (nixpkgs) pkgs;
 
   f = { mkDerivation, aeson, base, bytestring, containers, hspec
-      , lens, stdenv, text, unordered-containers, wreq
+      , lens, mtl, stdenv, text, transformers, unordered-containers, wreq
       }:
       mkDerivation {
         pname = "intercom-haskell";
         version = "0.1.0.0";
         src = ./.;
         libraryHaskellDepends = [
-          aeson base bytestring containers lens text unordered-containers
-          wreq
+          aeson base bytestring containers lens mtl text transformers
+          unordered-containers wreq
         ];
         testHaskellDepends = [
           aeson base bytestring hspec lens text unordered-containers


### PR DESCRIPTION
Using Monad Transformers, we can avoid explicitly passing the `Client` to each API function, and just expose a `withIntercom` function that runs the API query against the client.
